### PR TITLE
Replace "uses" by "run" in compose build action

### DIFF
--- a/.github/workflows/build_compose.yml
+++ b/.github/workflows/build_compose.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build-compose:


### PR DESCRIPTION
Replace "uses" by "run" in compose build action to prevent action failure